### PR TITLE
Build Using Active Profile Id

### DIFF
--- a/Editor/Build/DataBuilders/BuildScriptPackedMode.cs
+++ b/Editor/Build/DataBuilders/BuildScriptPackedMode.cs
@@ -210,7 +210,7 @@ namespace UnityEditor.AddressableAssets.Build.DataBuilders
         {
             ExtractDataTask extractData = new ExtractDataTask();
             List<CachedAssetState> carryOverCachedState = new List<CachedAssetState>();
-            var tempPath = Path.GetDirectoryName(Application.dataPath) + "/" + Addressables.LibraryPath + PlatformMappingService.GetPlatformPathSubFolder() + "/addressables_content_state.json";
+            var tempPath = Path.GetDirectoryName(Application.dataPath) + "/" + Addressables.LibraryPath + "/" + aaContext.Settings.profileSettings.GetProfileName(aaContext.Settings.activeProfileId) + "/" + PlatformMappingService.GetPlatformPathSubFolder() + "/addressables_content_state.json";
 
             var playerBuildVersion = builderInput.PlayerVersion;
             if (m_AllBundleInputDefs.Count > 0)


### PR DESCRIPTION
 - Separated builds to have library output folder that uses active profile id.